### PR TITLE
fix: container status reporting for "created" containers

### DIFF
--- a/src/utils/container-status.ts
+++ b/src/utils/container-status.ts
@@ -203,7 +203,6 @@ async function getContainerStatus(
 					resolve("stopped");
 				} else {
 					switch (stdout.trim()) {
-						case "created":
 						case "restarting":
 						case "running":
 							resolve("running");


### PR DESCRIPTION
The container status tracker reports `created` containers as `running`. This is invalid because a container can be created (e.g. with `docker create ...`) but never started.

Now, containers with `created` status are reported as `stopped`.