### PR TITLE
chore: improve log output formatting for logs and telemetry

### DIFF
--- a/src/plugins/logs.ts
+++ b/src/plugins/logs.ts
@@ -19,7 +19,7 @@ export default createPlugin(
 					stdio: "pipe",
 				},
 			);
-			pipeToLogOutputChannel(logsProcess, outputChannel, "");
+			pipeToLogOutputChannel(logsProcess, outputChannel, "[localstack.logs]: ");
 		};
 
 		const stopLogging = () => {

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -167,7 +167,7 @@ export function createTelemetry(
 
 			postEvent(extensionVersion, telemetryEvent).catch(() => {});
 
-			outputChannel.debug(
+			outputChannel.trace(
 				`[telemetry.event]: ${JSON.stringify(telemetryEvent)}`,
 			);
 		},

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -167,12 +167,9 @@ export function createTelemetry(
 
 			postEvent(extensionVersion, telemetryEvent).catch(() => {});
 
-			if (process.env.NODE_ENV === "development") {
-				// only log in output channel for development mode
-				outputChannel.info(
-					`Telemetry event tracked: ${JSON.stringify(telemetryEvent)}`,
-				);
-			}
+			outputChannel.debug(
+				`[telemetry.event]: ${JSON.stringify(telemetryEvent)}`,
+			);
 		},
 	};
 }


### PR DESCRIPTION
Adds a prefix to log output in the logs plugin for better identification and changes telemetry event logging to use debug level with a clear prefix. This enhances log readability and consistency.