### PR TITLE
feat: timeout container status checks after 1s

### DIFF
--- a/src/utils/container-status.ts
+++ b/src/utils/container-status.ts
@@ -191,6 +191,9 @@ async function getContainerStatus(
 	containerName: string,
 ): Promise<ContainerStatus> {
 	return new Promise((resolve) => {
+		// timeout after 1s
+		setTimeout(() => resolve("stopped"), 1_000);
+
 		exec(
 			`docker inspect --format {{.State.Status}} ${containerName}`,
 			(error, stdout) => {


### PR DESCRIPTION
Under unknown circumstances, `docker` commands may hang up for minutes. Since the LS Toolkit activation requires running some `docker` commands such as `docker inspect`, we now abort the command after 1s.