### PR TITLE
feat: add license check to setup wizard and status bar check

### DIFF
--- a/src/plugins/setup.ts
+++ b/src/plugins/setup.ts
@@ -192,8 +192,16 @@ export default createPlugin(
 
 								commands.executeCommand("localstack.openLicensePage");
 
-								await activateLicenseUntilValid(outputChannel);
+								await activateLicenseUntilValid(
+									outputChannel,
+									cancellationToken,
+								);
 							}
+
+							if (cancellationToken.isCancellationRequested) {
+								return;
+							}
+
 							//TODO add telemetry
 
 							/////////////////////////////////////////////////////////////////////

--- a/src/plugins/setup.ts
+++ b/src/plugins/setup.ts
@@ -11,6 +11,7 @@ import {
 import { configureAwsProfiles } from "../utils/configure-aws.ts";
 import { runInstallProcess } from "../utils/install.ts";
 import { minDelay } from "../utils/promises.ts";
+import {execLocalStack} from "../utils/cli.ts";
 
 export default createPlugin(
 	({ context, outputChannel, setupStatusTracker, telemetry }) => {
@@ -167,7 +168,9 @@ export default createPlugin(
 							/////////////////////////////////////////////////////////////////////
 							progress.report({ message: "Checking LocalStack license..." });
 
-							//TODO try to activate the license first
+                            const licenseActivateResponse = await execLocalStack(["license", "activate"], {
+                                outputChannel,
+                            });
 
 							const licenseIsValid = await minDelay(
 								checkIsLicenseValid(outputChannel),
@@ -252,7 +255,9 @@ async function checkLicenseUntilValid(
 		if (licenseIsValid) {
 			break;
 		}
-		//TODO try to activate the license
+        const licenseActivateResponse = await execLocalStack(["license", "activate"], {
+            outputChannel,
+        });
 
 		// Wait 2 seconds before trying again
 		await new Promise((resolve) => setTimeout(resolve, 2000));

--- a/src/plugins/setup.ts
+++ b/src/plugins/setup.ts
@@ -174,7 +174,6 @@ export default createPlugin(
 							// then there will be no license info to be reported by `localstack license info`.
 							// Also, an expired license could be cached.
 							// Activating the license pre-emptively to know its state during the setup process.
-							await activateLicense(outputChannel);
 							const licenseIsValid = await minDelay(
 								activateLicense(outputChannel).then(() =>
 									checkIsLicenseValid(outputChannel),

--- a/src/plugins/setup.ts
+++ b/src/plugins/setup.ts
@@ -5,6 +5,7 @@ import { commands, ProgressLocation, window } from "vscode";
 import { createPlugin } from "../plugins.ts";
 import {
 	checkIsAuthenticated,
+	checkIsLicenseValid,
 	requestAuthentication,
 	saveAuthToken,
 } from "../utils/authenticate.ts";
@@ -121,8 +122,6 @@ export default createPlugin(
 								progress.report({
 									message:
 										"Waiting for authentication response from the browser...",
-									// message: "Waiting for browser response...",
-									// message: "Waiting for authentication response...",
 								});
 								const { authToken } = await minDelay(
 									requestAuthentication(context, cancellationToken),
@@ -145,7 +144,6 @@ export default createPlugin(
 
 								/////////////////////////////////////////////////////////////////////
 								progress.report({
-									// message: "Authenticating...",
 									message: "Authenticating to file...",
 								});
 								await minDelay(saveAuthToken(authToken, outputChannel));
@@ -165,6 +163,21 @@ export default createPlugin(
 
 									return;
 								}
+							}
+
+							/////////////////////////////////////////////////////////////////////
+							progress.report({ message: "Checking LocalStack license..." });
+							const licenseIsValid = await minDelay(
+								checkIsLicenseValid(outputChannel),
+							);
+							if (licenseIsValid) {
+								progress.report({ message: "License verified succesfully..." });
+							} else {
+								progress.report({
+									message:
+										"License is not valid or not assigned, please check License settings page...",
+								});
+								commands.executeCommand("localstack.openLicensePage");
 							}
 
 							/////////////////////////////////////////////////////////////////////

--- a/src/plugins/setup.ts
+++ b/src/plugins/setup.ts
@@ -8,10 +8,10 @@ import {
 	requestAuthentication,
 	saveAuthToken,
 } from "../utils/authenticate.ts";
+import { execLocalStack } from "../utils/cli.ts";
 import { configureAwsProfiles } from "../utils/configure-aws.ts";
 import { runInstallProcess } from "../utils/install.ts";
 import { minDelay } from "../utils/promises.ts";
-import {execLocalStack} from "../utils/cli.ts";
 
 export default createPlugin(
 	({ context, outputChannel, setupStatusTracker, telemetry }) => {
@@ -168,10 +168,9 @@ export default createPlugin(
 							/////////////////////////////////////////////////////////////////////
 							progress.report({ message: "Checking LocalStack license..." });
 
-                            const licenseActivateResponse = await execLocalStack(["license", "activate"], {
-                                outputChannel,
-                            });
-
+							await execLocalStack(["license", "activate"], {
+								outputChannel,
+							});
 							const licenseIsValid = await minDelay(
 								checkIsLicenseValid(outputChannel),
 							);
@@ -182,7 +181,7 @@ export default createPlugin(
 							} else {
 								progress.report({
 									message:
-										"License is not valid or not assigned, please check License settings page...",
+										"License is not valid or not assigned. Open License settings page to activate it.",
 								});
 								commands.executeCommand("localstack.openLicensePage");
 								await checkLicenseUntilValid(outputChannel);
@@ -255,10 +254,9 @@ async function checkLicenseUntilValid(
 		if (licenseIsValid) {
 			break;
 		}
-        const licenseActivateResponse = await execLocalStack(["license", "activate"], {
-            outputChannel,
-        });
-
+		await execLocalStack(["license", "activate"], {
+			outputChannel,
+		});
 		// Wait 2 seconds before trying again
 		await new Promise((resolve) => setTimeout(resolve, 2000));
 	}

--- a/src/plugins/setup.ts
+++ b/src/plugins/setup.ts
@@ -168,6 +168,10 @@ export default createPlugin(
 							/////////////////////////////////////////////////////////////////////
 							progress.report({ message: "Checking LocalStack license..." });
 
+							// If an auth token has just been obtained or LocalStack has never been started,
+							// then there will be no license info to be reported by `localstack license info`.
+							// Also, an expired license could be cached.
+							// Activating the license pre-emptively to know its state during the setup process.
 							await execLocalStack(["license", "activate"], {
 								outputChannel,
 							});
@@ -183,9 +187,12 @@ export default createPlugin(
 									message:
 										"License is not valid or not assigned. Open License settings page to activate it.",
 								});
+
 								commands.executeCommand("localstack.openLicensePage");
+
 								await checkLicenseUntilValid(outputChannel);
 							}
+							//TODO add telemetry
 
 							/////////////////////////////////////////////////////////////////////
 							progress.report({

--- a/src/plugins/setup.ts
+++ b/src/plugins/setup.ts
@@ -179,11 +179,7 @@ export default createPlugin(
 									checkIsLicenseValid(outputChannel),
 								),
 							);
-							if (licenseIsValid) {
-								progress.report({
-									message: "License verified successfully...",
-								});
-							} else {
+							if (!licenseIsValid) {
 								progress.report({
 									message:
 										"License is not valid or not assigned. Open License settings page to activate it.",

--- a/src/plugins/setup.ts
+++ b/src/plugins/setup.ts
@@ -176,7 +176,9 @@ export default createPlugin(
 							// Activating the license pre-emptively to know its state during the setup process.
 							await activateLicense(outputChannel);
 							const licenseIsValid = await minDelay(
-								checkIsLicenseValid(outputChannel),
+								activateLicense(outputChannel).then(() =>
+									checkIsLicenseValid(outputChannel),
+								),
 							);
 							if (licenseIsValid) {
 								progress.report({

--- a/src/plugins/setup.ts
+++ b/src/plugins/setup.ts
@@ -264,7 +264,7 @@ async function checkLicenseUntilValid(
 		await execLocalStack(["license", "activate"], {
 			outputChannel,
 		});
-		// Wait 2 seconds before trying again
-		await new Promise((resolve) => setTimeout(resolve, 2000));
+		// Wait before trying again
+		await new Promise((resolve) => setTimeout(resolve, 1000));
 	}
 }

--- a/src/utils/authenticate.ts
+++ b/src/utils/authenticate.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -125,7 +124,7 @@ export async function checkIsLicenseValid(outputChannel: LogOutputChannel) {
 	} catch (error) {
 		outputChannel.error(error instanceof Error ? error : String(error));
 
-		return undefined;
+		return false;
 	}
 }
 

--- a/src/utils/authenticate.ts
+++ b/src/utils/authenticate.ts
@@ -10,7 +10,6 @@ import type {
 import { env, Uri, window } from "vscode";
 
 import { assertIsError } from "./assert.ts";
-import { execLocalStack } from "./cli.ts";
 
 /**
  * Registers a {@link UriHandler} that waits for an authentication token from the browser,
@@ -110,21 +109,6 @@ export async function saveAuthToken(
 			.then(() => {
 				outputChannel.show(true);
 			});
-	}
-}
-
-const LICENSE_VALIDITY_MARKER = "license validity: valid";
-
-export async function checkIsLicenseValid(outputChannel: LogOutputChannel) {
-	try {
-		const licenseInfoResponse = await execLocalStack(["license", "info"], {
-			outputChannel,
-		});
-		return licenseInfoResponse.stdout.includes(LICENSE_VALIDITY_MARKER);
-	} catch (error) {
-		outputChannel.error(error instanceof Error ? error : String(error));
-
-		return false;
 	}
 }
 

--- a/src/utils/license.ts
+++ b/src/utils/license.ts
@@ -1,0 +1,38 @@
+import type { LogOutputChannel } from "vscode";
+
+import { execLocalStack } from "./cli.ts";
+
+const LICENSE_VALIDITY_MARKER = "license validity: valid";
+
+export async function checkIsLicenseValid(outputChannel: LogOutputChannel) {
+	try {
+		const licenseInfoResponse = await execLocalStack(["license", "info"], {
+			outputChannel,
+		});
+		return licenseInfoResponse.stdout.includes(LICENSE_VALIDITY_MARKER);
+	} catch (error) {
+		outputChannel.error(error instanceof Error ? error : String(error));
+
+		return false;
+	}
+}
+
+export async function activateLicense(outputChannel: LogOutputChannel) {
+	await execLocalStack(["license", "activate"], {
+		outputChannel,
+	});
+}
+
+export async function activateLicenseUntilValid(
+	outputChannel: LogOutputChannel,
+): Promise<void> {
+	while (true) {
+		const licenseIsValid = await checkIsLicenseValid(outputChannel);
+		if (licenseIsValid) {
+			break;
+		}
+		await activateLicense(outputChannel);
+		// Wait before trying again
+		await new Promise((resolve) => setTimeout(resolve, 1000));
+	}
+}

--- a/src/utils/license.ts
+++ b/src/utils/license.ts
@@ -18,9 +18,13 @@ export async function checkIsLicenseValid(outputChannel: LogOutputChannel) {
 }
 
 export async function activateLicense(outputChannel: LogOutputChannel) {
-	await execLocalStack(["license", "activate"], {
-		outputChannel,
-	});
+	try {
+		await execLocalStack(["license", "activate"], {
+			outputChannel,
+		});
+	} catch (error) {
+		outputChannel.error(error instanceof Error ? error : String(error));
+	}
 }
 
 export async function activateLicenseUntilValid(

--- a/src/utils/license.ts
+++ b/src/utils/license.ts
@@ -1,4 +1,4 @@
-import type { LogOutputChannel } from "vscode";
+import type { CancellationToken, LogOutputChannel } from "vscode";
 
 import { execLocalStack } from "./cli.ts";
 
@@ -29,8 +29,12 @@ export async function activateLicense(outputChannel: LogOutputChannel) {
 
 export async function activateLicenseUntilValid(
 	outputChannel: LogOutputChannel,
+	cancellationToken: CancellationToken,
 ): Promise<void> {
 	while (true) {
+		if (cancellationToken.isCancellationRequested) {
+			break;
+		}
 		const licenseIsValid = await checkIsLicenseValid(outputChannel);
 		if (licenseIsValid) {
 			break;

--- a/src/utils/manage.ts
+++ b/src/utils/manage.ts
@@ -2,9 +2,9 @@ import { v7 as uuidv7 } from "uuid";
 import type { ExtensionContext, LogOutputChannel, MessageItem } from "vscode";
 import { commands, env, Uri, window } from "vscode";
 
-import { checkIsLicenseValid } from "./authenticate.ts";
 import { spawnLocalStack } from "./cli.ts";
 import { exec } from "./exec.ts";
+import { checkIsLicenseValid } from "./license.ts";
 import type { Telemetry } from "./telemetry.ts";
 
 export type LocalstackStatus = "running" | "starting" | "stopping" | "stopped";

--- a/src/utils/manage.ts
+++ b/src/utils/manage.ts
@@ -183,7 +183,12 @@ export async function stopLocalStack(
 
 export async function openLicensePage() {
 	const url = new URL("https://app.localstack.cloud/settings/auth-tokens");
-	await env.openExternal(Uri.parse(url.toString()));
+	const openSuccessful = await env.openExternal(Uri.parse(url.toString()));
+	if (!openSuccessful) {
+		window.showErrorMessage(
+			`Open LocalStack License page in browser by entering the URL manually: ${url.toString()}`,
+		);
+	}
 }
 
 async function showInformationMessage(

--- a/src/utils/promises.ts
+++ b/src/utils/promises.ts
@@ -1,9 +1,9 @@
 import pMinDelay from "p-min-delay";
 
 /**
- * Setting up a minimum wait time of 1s allows users
+ * Setting up a minimum wait time allows users
  * to visually grasp the text before it goes away, if
- * the task was fast (less than 0.5s).
+ * the task was faster than the minimum wait time.
  */
 const MIN_TIME_BETWEEN_STEPS_MS = 500;
 

--- a/src/utils/setup.ts
+++ b/src/utils/setup.ts
@@ -3,17 +3,20 @@ import type { LogOutputChannel } from "vscode";
 import { checkIsAuthenticated } from "./authenticate.ts";
 import { checkIsProfileConfigured } from "./configure-aws.ts";
 import { checkLocalstackInstalled } from "./install.ts";
+import { checkIsLicenseValid } from "./license.ts";
 
 export async function checkIsSetupRequired(
 	outputChannel: LogOutputChannel,
 ): Promise<boolean> {
-	const [isInstalled, isAuthenticated, isProfileConfigured] = await Promise.all(
-		[
+	const [isInstalled, isAuthenticated, isLicenseValid, isProfileConfigured] =
+		await Promise.all([
 			checkLocalstackInstalled(outputChannel),
 			checkIsAuthenticated(),
+			checkIsLicenseValid(outputChannel),
 			checkIsProfileConfigured(),
-		],
-	);
+		]);
 
-	return !isInstalled || !isAuthenticated || !isProfileConfigured;
+	return (
+		!isInstalled || !isAuthenticated || !isLicenseValid || !isProfileConfigured
+	);
 }


### PR DESCRIPTION
Adds checking for localstack license during the setup process and as a part of `isSetupRequired` checks on startup and in status bar.

Also adds proactive license activation to mitigate caching issues and unnecessary redirects when activation can be done in the background.

License check and activation are performed right after authentication.

Updated setup flow with license activation:

![auth_and_license_activation_in_setup_wizard](https://github.com/user-attachments/assets/25fd1190-43ff-42c8-a939-eaea10f99f8a)


Note: Not adding telemetry yet as I want to clarify schema update process first - this PR adds another step in the middle of setup flow therefore step positions shift.