### PR TITLE
chore: separate test and list ci jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,8 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Build
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
 
     steps:
@@ -29,6 +29,22 @@ jobs:
 
       - name: Lint
         run: npx eslint
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Type check
         run: npx tsc


### PR DESCRIPTION
Currently, linting, compiling and testing happens during the same CI 
job, making it hard to distinguish if the CI didn’t pass because of a 
linting issue or because the code does not work.

This change separates the current build job into two: lint and test.