### PR TITLE
feat: reflect LS status immediately after running start and stop commands

### DIFF
--- a/src/plugins/manage.ts
+++ b/src/plugins/manage.ts
@@ -17,13 +17,17 @@ export default createPlugin(
 		);
 
 		context.subscriptions.push(
-			commands.registerCommand("localstack.start", () => {
+			commands.registerCommand("localstack.start", async () => {
 				if (localStackStatusTracker.status() !== "stopped") {
 					window.showInformationMessage("LocalStack is already running.");
 					return;
 				}
-				localStackStatusTracker.forceStarting();
-				void startLocalStack(outputChannel, telemetry);
+				localStackStatusTracker.forceContainerStatus("running");
+				try {
+					await startLocalStack(outputChannel, telemetry);
+				} catch {
+					localStackStatusTracker.forceContainerStatus("stopped");
+				}
 			}),
 		);
 
@@ -33,7 +37,7 @@ export default createPlugin(
 					window.showInformationMessage("LocalStack is not running.");
 					return;
 				}
-				localStackStatusTracker.forceStopping();
+				localStackStatusTracker.forceContainerStatus("stopping");
 				void stopLocalStack(outputChannel, telemetry);
 			}),
 		);

--- a/src/plugins/manage.ts
+++ b/src/plugins/manage.ts
@@ -1,4 +1,4 @@
-import { commands } from "vscode";
+import { commands, window } from "vscode";
 
 import { createPlugin } from "../plugins.ts";
 import {
@@ -9,7 +9,7 @@ import {
 
 export default createPlugin(
 	"manage",
-	({ context, outputChannel, telemetry }) => {
+	({ context, outputChannel, telemetry, localStackStatusTracker }) => {
 		context.subscriptions.push(
 			commands.registerCommand("localstack.viewLogs", () => {
 				outputChannel.show(true);
@@ -18,12 +18,22 @@ export default createPlugin(
 
 		context.subscriptions.push(
 			commands.registerCommand("localstack.start", () => {
+				if (localStackStatusTracker.status() !== "stopped") {
+					window.showInformationMessage("LocalStack is already running.");
+					return;
+				}
+				localStackStatusTracker.forceStarting();
 				void startLocalStack(outputChannel, telemetry);
 			}),
 		);
 
 		context.subscriptions.push(
 			commands.registerCommand("localstack.stop", () => {
+				if (localStackStatusTracker.status() !== "running") {
+					window.showInformationMessage("LocalStack is not running.");
+					return;
+				}
+				localStackStatusTracker.forceStopping();
 				void stopLocalStack(outputChannel, telemetry);
 			}),
 		);

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -8,6 +8,7 @@ import { CLI_PATHS } from "../constants.ts";
 
 import { exec } from "./exec.ts";
 import { spawn } from "./spawn.ts";
+import type { SpawnOptions } from "./spawn.ts";
 
 const IMAGE_NAME = "localstack/localstack-pro";
 const LOCALSTACK_LDM_PREVIEW = "1";
@@ -68,6 +69,7 @@ export const spawnLocalStack = async (
 	options: {
 		outputChannel: LogOutputChannel;
 		cancellationToken?: CancellationToken;
+		onStderr?: SpawnOptions["onStderr"];
 	},
 ) => {
 	const cli = await findLocalStack();
@@ -81,5 +83,6 @@ export const spawnLocalStack = async (
 			IMAGE_NAME,
 			LOCALSTACK_LDM_PREVIEW,
 		},
+		onStderr: options.onStderr,
 	});
 };

--- a/src/utils/localstack-status.ts
+++ b/src/utils/localstack-status.ts
@@ -34,7 +34,6 @@ export async function createLocalStackStatusTracker(
 	const setStatus = (newStatus: LocalStackStatus) => {
 		if (status !== newStatus) {
 			status = newStatus;
-			outputChannel.debug(`[localstack.status]: ${status}`);
 			void emitter.emit(status);
 		}
 	};

--- a/src/utils/localstack-status.ts
+++ b/src/utils/localstack-status.ts
@@ -11,9 +11,7 @@ export type LocalStackStatus = "starting" | "running" | "stopping" | "stopped";
 
 export interface LocalStackStatusTracker extends Disposable {
 	status(): LocalStackStatus;
-	// setStatus(status: LocalStackStatus): void;
-	forceStarting(): void;
-	forceStopping(): void;
+	forceContainerStatus(status: ContainerStatus): void;
 	onChange(callback: (status: LocalStackStatus) => void): void;
 }
 
@@ -66,15 +64,9 @@ export async function createLocalStackStatusTracker(
 			// biome-ignore lint/style/noNonNullAssertion: false positive
 			return status!;
 		},
-		forceStarting() {
-			if (containerStatus !== "running") {
-				containerStatus = "running";
-				deriveStatus();
-			}
-		},
-		forceStopping() {
-			if (containerStatus !== "stopping") {
-				containerStatus = "stopping";
+		forceContainerStatus(newContainerStatus) {
+			if (containerStatus !== newContainerStatus) {
+				containerStatus = newContainerStatus;
 				deriveStatus();
 			}
 		},

--- a/src/utils/localstack-status.ts
+++ b/src/utils/localstack-status.ts
@@ -11,6 +11,9 @@ export type LocalStackStatus = "starting" | "running" | "stopping" | "stopped";
 
 export interface LocalStackStatusTracker extends Disposable {
 	status(): LocalStackStatus;
+	// setStatus(status: LocalStackStatus): void;
+	forceStarting(): void;
+	forceStopping(): void;
 	onChange(callback: (status: LocalStackStatus) => void): void;
 }
 
@@ -22,30 +25,36 @@ export async function createLocalStackStatusTracker(
 	outputChannel: LogOutputChannel,
 	timeTracker: TimeTracker,
 ): Promise<LocalStackStatusTracker> {
+	let containerStatus: ContainerStatus | undefined;
 	let status: LocalStackStatus | undefined;
 	const emitter = createEmitter<LocalStackStatus>(outputChannel);
 
 	let healthCheck: boolean | undefined;
 
-	const updateStatus = () => {
-		const newStatus = getLocalStackStatus(
-			containerStatusTracker.status(),
-			healthCheck,
-		);
+	const setStatus = (newStatus: LocalStackStatus) => {
 		if (status !== newStatus) {
 			status = newStatus;
+			outputChannel.debug(`[localstack.status]: ${status}`);
 			void emitter.emit(status);
 		}
 	};
 
-	containerStatusTracker.onChange(() => {
-		updateStatus();
+	const deriveStatus = () => {
+		const newStatus = getLocalStackStatus(containerStatus, healthCheck);
+		setStatus(newStatus);
+	};
+
+	containerStatusTracker.onChange((newContainerStatus) => {
+		if (containerStatus !== newContainerStatus) {
+			containerStatus = newContainerStatus;
+			deriveStatus();
+		}
 	});
 
 	let healthCheckTimeout: NodeJS.Timeout | undefined;
 	const startHealthCheck = async () => {
 		healthCheck = await fetchHealth();
-		updateStatus();
+		deriveStatus();
 		healthCheckTimeout = setTimeout(() => void startHealthCheck(), 1_000);
 	};
 
@@ -57,6 +66,18 @@ export async function createLocalStackStatusTracker(
 		status() {
 			// biome-ignore lint/style/noNonNullAssertion: false positive
 			return status!;
+		},
+		forceStarting() {
+			if (containerStatus !== "running") {
+				containerStatus = "running";
+				deriveStatus();
+			}
+		},
+		forceStopping() {
+			if (containerStatus !== "stopping") {
+				containerStatus = "stopping";
+				deriveStatus();
+			}
 		},
 		onChange(callback) {
 			emitter.on(callback);

--- a/src/utils/manage.ts
+++ b/src/utils/manage.ts
@@ -108,6 +108,8 @@ export async function startLocalStack(
 				outputChannel,
 				onStderr(data: Buffer, context) {
 					const text = data.toString();
+					// Currently, the LocalStack CLI does not return a non-zero exit code if the container fails to start.
+					// As a workaround, we look for a specific error message in the output to determine if the container failed to start.
 					if (
 						text.includes(
 							"localstack.utils.container_utils.container_client.ContainerException",

--- a/src/utils/manage.ts
+++ b/src/utils/manage.ts
@@ -108,7 +108,7 @@ export async function startLocalStack(
 				outputChannel,
 				onStderr(data: Buffer, context) {
 					const text = data.toString();
-					// Currently, the LocalStack CLI does not return a non-zero exit code if the container fails to start.
+					// Currently, the LocalStack CLI does not exit if the container fails to start in specific scenarios.
 					// As a workaround, we look for a specific error message in the output to determine if the container failed to start.
 					if (
 						text.includes(

--- a/src/utils/manage.ts
+++ b/src/utils/manage.ts
@@ -115,6 +115,7 @@ export async function startLocalStack(
 							"localstack.utils.container_utils.container_client.ContainerException",
 						)
 					) {
+						// Abort the process if we detect a ContainerException, otherwise it will hang indefinitely.
 						context.abort();
 						throw new Error("ContainerException");
 					}


### PR DESCRIPTION
- Make status bar reflect "starting" or "stopping" immediately after running LocalStack start/stop commands.
- Add heuristic to handle LocalStack CLI failures by inspecting output text.


-----------------------

This one is delicate: we synthetically force the container status to "running", "stopping" and "stopped" to give the user the immediate effect of their actions on the status bar.

In order to do so I refactored a bit our spawn helpers, no big deal, they are now just a bit more complex. On top of that, our localstack start --detached invocation is a bit more complex: we look for a specific error string in its stderr output - in that case, we kill the process and throw an error. In turn, we force back the container status to "stopped".
