### PR TITLE
chore: enable eslint rule to detect floating promises

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,11 @@ export default tseslint.config(
 			"@typescript-eslint/no-explicit-any": "off",
 			// Covered by @typescript-eslint/no-floating-promises.
 			"@typescript-eslint/require-await": "warn",
+			// Customize @typescript-eslint/no-floating-promises.
+			"@typescript-eslint/no-floating-promises": [
+				"warn",
+				{ checkThenables: true },
+			],
 		},
 	},
 	{


### PR DESCRIPTION
A "floating" Promise is one that is created without any code set up to handle any errors it might throw. Floating Promises can cause several issues, such as improperly sequenced operations, ignored Promise rejections, and more.