### PR TITLE
fix: check hostname for profile endpoint url

### DIFF
--- a/src/utils/configure-aws.ts
+++ b/src/utils/configure-aws.ts
@@ -57,8 +57,7 @@ function isValidEndpointUrl(url: string | undefined): boolean {
 		return (
 			(parsed.protocol === "http:" || parsed.protocol === "https:") &&
 			VALID_HOSTNAMES.includes(parsed.hostname) &&
-			parsed.port !== "" && // port must be present
-			(parsed.port === DEFAULT_PORT || /^\d+$/.test(parsed.port))
+			parsed.port // port must be present
 		);
 	} catch {
 		return false;

--- a/src/utils/configure-aws.ts
+++ b/src/utils/configure-aws.ts
@@ -40,12 +40,12 @@ async function overrideSelection(
 	override: boolean = false,
 ): Promise<OverrideDecision | undefined> {
 	if (override === true) {
-		return "override";
+		return "Override";
 	}
 	const fileList = filesToModify.join(" and ");
 	const selection = await window.showWarningMessage(
 		`The "localstack" AWS profile in ${fileList} exists, but does not match the expected properties. Do you want to override it?`,
-		"override",
+		"Override",
 	);
 	return selection;
 }
@@ -93,7 +93,7 @@ async function dnsResolveCheck(): Promise<boolean> {
 	}
 }
 
-type OverrideDecision = "override" | "do_not_override";
+type OverrideDecision = "Override" | "do_not_override";
 
 async function configureAwsConfigProfile(
 	awsConfigFilename: string,
@@ -110,7 +110,7 @@ async function configureAwsConfigProfile(
 	try {
 		if (section) {
 			// LocalStack profile exists, but does not match the expected properties
-			if (overrideDecision === "override") {
+			if (overrideDecision === "Override") {
 				// User chose to override the existing profile.
 
 				// check if dnsResolveCheck is successful
@@ -186,7 +186,7 @@ async function configureCredentialsProfile(
 	try {
 		// LocalStack profile exists, but does not match the expected properties
 		if (section) {
-			if (overrideDecision === "override") {
+			if (overrideDecision === "Override") {
 				// User chose to override the existing profile.
 				const updatedIniFile = updateIniSection(
 					iniFile,
@@ -321,7 +321,7 @@ export async function configureAwsProfiles(options: {
 			// profiles are there but need adjustment
 			// in testing, we always override
 			if (options?.forceOverride) {
-				overrideDecision = "override";
+				overrideDecision = "Override";
 			} else {
 				// check which files need override
 				const filesToModify = [];
@@ -333,7 +333,7 @@ export async function configureAwsProfiles(options: {
 		}
 	} else {
 		// if any of the profiles don't exist, we need to create it
-		overrideDecision = "override";
+		overrideDecision = "Override";
 	}
 
 	if (overrideDecision === undefined) {
@@ -350,7 +350,7 @@ export async function configureAwsProfiles(options: {
 			},
 		});
 		return;
-	} else if (overrideDecision === "override") {
+	} else if (overrideDecision === "Override") {
 		if (configNeedsOverride && credentialsNeedsOverride) {
 			[configModified, credentialsModified] = await Promise.all([
 				configureAwsConfigProfile(

--- a/src/utils/configure-aws.ts
+++ b/src/utils/configure-aws.ts
@@ -15,9 +15,12 @@ import type { Telemetry } from "./telemetry.ts";
 
 const LOCALSTACK_CONFIG_PROFILE_NAME = "profile localstack";
 const VALID_ENDPOINT_URLS = [
-	"http://localhost.localstack.cloud:4566", // default
+	"http://localhost.localstack.cloud:4566",
+	"https://localhost.localstack.cloud:4566",
 	"http://127.0.0.1:4566",
+	"https://127.0.0.1:4566",
 	"http://localhost:4566",
+	"https://localhost:4566",
 ];
 const LOCALSTACK_CONFIG_PROPERTIES = {
 	region: "us-east-1",
@@ -143,8 +146,8 @@ async function configureAwsConfigProfile(
 		// check if dnsResolveCheck is successful
 		const isDnsResolved = await dnsResolveCheck();
 		const endpointUrl = isDnsResolved
-			? "http://localhost.localstack.cloud:4566"
-			: VALID_ENDPOINT_URLS[1];
+			? "https://localhost.localstack.cloud:4566"
+			: "https://127.0.0.1:4566";
 
 		const updatedIniFile = updateIniSection(
 			iniFile,

--- a/src/utils/configure-aws.ts
+++ b/src/utils/configure-aws.ts
@@ -57,7 +57,7 @@ function isValidEndpointUrl(url: string | undefined): boolean {
 		return (
 			(parsed.protocol === "http:" || parsed.protocol === "https:") &&
 			VALID_HOSTNAMES.includes(parsed.hostname) &&
-			parsed.port // port must be present
+			parsed.port !== "" // port must be present
 		);
 	} catch {
 		return false;


### PR DESCRIPTION
- Use uppercase "Override" in aws profile override.
- Check hostname instead of only http protocol (https should also work)