### PR TITLE
fix: don't show start localstack if started during setup

### DIFF
--- a/src/plugins/setup.ts
+++ b/src/plugins/setup.ts
@@ -17,7 +17,13 @@ import { minDelay } from "../utils/promises.ts";
 
 export default createPlugin(
 	"setup",
-	({ context, outputChannel, setupStatusTracker, telemetry }) => {
+	({
+		context,
+		outputChannel,
+		setupStatusTracker,
+		localStackStatusTracker,
+		telemetry,
+	}) => {
 		context.subscriptions.push(
 			commands.registerCommand(
 				"localstack.setup",
@@ -219,16 +225,29 @@ export default createPlugin(
 							await minDelay(Promise.resolve());
 
 							/////////////////////////////////////////////////////////////////////
-							window
-								.showInformationMessage("LocalStack is ready to start", {
-									title: "Start LocalStack",
-									command: "localstack.start",
-								})
-								.then((selection) => {
-									if (selection) {
-										commands.executeCommand(selection.command);
-									}
-								});
+							if (localStackStatusTracker.status() === "running") {
+								window
+									.showInformationMessage("LocalStack is running.", {
+										title: "View Logs",
+										command: "localstack.viewLogs",
+									})
+									.then((selection) => {
+										if (selection) {
+											commands.executeCommand(selection.command);
+										}
+									});
+							} else {
+								window
+									.showInformationMessage("LocalStack is ready to start.", {
+										title: "Start LocalStack",
+										command: "localstack.start",
+									})
+									.then((selection) => {
+										if (selection) {
+											commands.executeCommand(selection.command);
+										}
+									});
+							}
 
 							telemetry.track({
 								name: "setup_ended",


### PR DESCRIPTION
As a last step of the setup wizard, we always show "Start LocalStack" even if the user has localstack running (e.g. in the case of re-running setup wizard).

Fixes [this](https://www.notion.so/localstack/LS-Toolkit-asks-to-start-LS-when-it-s-already-running-263fc2a2343180fd9ae5dbe31daf5da8).