### PR TITLE
fix(status-bar): invalid status reported when stopping LocalStack externally

### DIFF
--- a/src/utils/localstack-status.ts
+++ b/src/utils/localstack-status.ts
@@ -37,7 +37,7 @@ export async function createLocalStackStatusTracker(
 	};
 
 	const deriveStatus = () => {
-		const newStatus = getLocalStackStatus(containerStatus, healthCheck);
+		const newStatus = getLocalStackStatus(containerStatus, healthCheck, status);
 		setStatus(newStatus);
 	};
 
@@ -85,11 +85,15 @@ export async function createLocalStackStatusTracker(
 function getLocalStackStatus(
 	containerStatus: ContainerStatus | undefined,
 	healthCheck: boolean | undefined,
+	previousStatus?: LocalStackStatus,
 ): LocalStackStatus {
 	if (containerStatus === "running") {
 		if (healthCheck === true) {
 			return "running";
 		} else {
+			if (previousStatus === "running" || previousStatus === "stopping") {
+				return "stopping";
+			}
 			return "starting";
 		}
 	} else if (containerStatus === "stopping") {

--- a/src/utils/localstack-status.ts
+++ b/src/utils/localstack-status.ts
@@ -91,6 +91,9 @@ function getLocalStackStatus(
 		if (healthCheck === true) {
 			return "running";
 		} else {
+			// When the LS container is running, and the health check fails:
+			// - If the previous status was "running", we are likely stopping LS
+			// - If the previous status was "stopping", we are still stopping LS
 			if (previousStatus === "running" || previousStatus === "stopping") {
 				return "stopping";
 			}


### PR DESCRIPTION
Fix status bar incorrectly reporting LocalStack as starting when stopping in certain scenarios